### PR TITLE
fixed webgl patcher affecting Windows builds

### DIFF
--- a/ThreadingPatcher/Editor/WebGLThreadingPatcher.asmdef
+++ b/ThreadingPatcher/Editor/WebGLThreadingPatcher.asmdef
@@ -14,8 +14,10 @@
         "Mono.Cecil.Pdb.dll",
         "Mono.Cecil.Rocks.dll"
     ],
-    "autoReferenced": true,
-    "defineConstraints": [],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_WEBGL"
+    ],
     "versionDefines": [],
     "noEngineReferences": false
 }

--- a/ThreadingPatcher/Runtime/WebGLThreadingPatcher.Runtime.asmdef
+++ b/ThreadingPatcher/Runtime/WebGLThreadingPatcher.Runtime.asmdef
@@ -2,13 +2,18 @@
     "name": "WebGLThreadingPatcher.Runtime",
     "rootNamespace": "WebGLThreadingPatcher.Runtime",
     "references": [],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor",
+        "WebGL"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
+    "overrideReferences": true,
     "precompiledReferences": [],
-    "autoReferenced": true,
-    "defineConstraints": [],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_WEBGL"
+    ],
     "versionDefines": [],
     "noEngineReferences": false
 }


### PR DESCRIPTION
also, "autoReferenced: true" is not necessary