### PR TITLE
Fix compilation on Unity 2022.1 and newer

### DIFF
--- a/ThreadingPatcher/Editor/WebGLThreadingPatcher.cs
+++ b/ThreadingPatcher/Editor/WebGLThreadingPatcher.cs
@@ -18,7 +18,12 @@ namespace WebGLThreadingPatcher.Editor
             if (report.summary.platform != BuildTarget.WebGL)
                 return;
 
-            var mscorLibDll = report.files.FirstOrDefault(f => f.path.EndsWith("mscorlib.dll")).path;
+#if UNITY_2022_1_OR_NEWER
+            var buildFiles = report.GetFiles();
+#else
+            var buildFiles = report.files;
+#endif
+            var mscorLibDll = buildFiles.FirstOrDefault(f => f.path.EndsWith("mscorlib.dll")).path;
             if (mscorLibDll == null)
             {
                 Debug.LogError("Can't find mscorlib.dll in build dll files");


### PR DESCRIPTION
`GetFiles()` replaced `BuildReport.files` in 2022.1. On Unity 6000.0.58f2 the old property is obsolete as an *error*, so the package no longer compiles there:

```
ThreadingPatcher/Editor/WebGLThreadingPatcher.cs(21,31): error CS0619:
'BuildReport.files' is obsolete: 'Use GetFiles() method instead (UnityUpgradable) -> GetFiles()'
```

It is an error rather than a warning, so it cannot be suppressed with `-nowarn` or a pragma — the editor assembly does not build, and with it neither does the WebGL player, since the patcher runs as a build post-processor.

The call is behind `UNITY_2022_1_OR_NEWER`, so editors down to the 2019.3 that `package.json` declares keep using the property. Both members return `BuildFile[]`, so nothing else changes.

`5ea34b79b` fixed the IL side of Unity 6 support; this is the remaining break, on the editor API side.

Verified on Unity 6000.0.58f2, where the package compiles with this change and a WebGL player builds and runs. The version boundary comes from the script reference — 2021.3 documents `files` and has no `GetFiles`, 2022.1 the other way round — not from a build on those editors.